### PR TITLE
リリース 250727 サムネイル修正

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -129,7 +129,7 @@ const logger = new StructuredLogger();
 
 // Global declaration for compatibility
 declare global {
-  // eslint-disable-next-line no-var
+   
   var logger: Logger;
 }
 

--- a/scripts/generate-thumbnails-post.ts
+++ b/scripts/generate-thumbnails-post.ts
@@ -1,40 +1,25 @@
 import fs from "fs/promises";
+import fsSync from "fs";
 import path from "path";
 import puppeteer from "puppeteer";
 import http from "http";
 import handler from "serve-handler";
 
 // Helper functions to discover presentations
-function getAllPresentations() {
+function getAllPresentations(): Array<{ slug: string }> {
   try {
     const presentationsDir = path.join(process.cwd(), "out", "presentations");
-    const items: any[] = require('fs').readdirSync(presentationsDir, { withFileTypes: true });
+    const items = fsSync.readdirSync(presentationsDir, { withFileTypes: true });
     
     return items
-      .filter((item: any) => item.isDirectory())
-      .map((item: any) => ({ slug: item.name }));
+      .filter((item) => item.isDirectory())
+      .map((item) => ({ slug: item.name }));
   } catch (error) {
     console.error("Error reading presentation directories:", error);
     return [];
   }
 }
 
-function getPresentationData(slug: string) {
-  try {
-    const presentationDir = path.join(process.cwd(), "out", "presentations", slug);
-    const items: any[] = require('fs').readdirSync(presentationDir, { withFileTypes: true });
-    
-    const pageNumbers = items
-      .filter((item: any) => item.isDirectory() && /^\d+$/.test(item.name))
-      .map((item: any) => parseInt(item.name))
-      .sort((a, b) => a - b);
-    
-    return { totalPages: pageNumbers.length > 0 ? Math.max(...pageNumbers) : 0 };
-  } catch (error) {
-    console.error(`Error reading presentation ${slug}:`, error);
-    return { totalPages: 0 };
-  }
-}
 
 // Main async function to generate thumbnails
 (async () => {
@@ -68,7 +53,6 @@ function getPresentationData(slug: string) {
       const presentations = getAllPresentations();
       for (const pres of presentations) {
         const { slug } = pres;
-        const { totalPages } = getPresentationData(slug);
         const slugDir = path.join(thumbsRoot, slug);
         await fs.mkdir(slugDir, { recursive: true });
 
@@ -85,9 +69,9 @@ function getPresentationData(slug: string) {
           const privatePath = path.join(process.cwd(), 'public', 'slides', 'private', slug, `${p}.html`);
           
           let htmlPath: string;
-          if (require('fs').existsSync(publicPath)) {
+          if (fsSync.existsSync(publicPath)) {
             htmlPath = publicPath;
-          } else if (require('fs').existsSync(privatePath)) {
+          } else if (fsSync.existsSync(privatePath)) {
             htmlPath = privatePath;
           } else {
             console.error(`❌ HTML file not found for ${slug}/${p}`);


### PR DESCRIPTION
This pull request introduces several changes to improve the thumbnail generation script and refines logging compatibility. The key updates include enhancements to the `scripts/generate-thumbnails-post.ts` file for better handling of presentation data and HTML file paths, as well as minor adjustments to the global logger declaration.

### Thumbnail generation improvements:

* **Refactor of `getAllPresentations` function:** Updated to use `fsSync.readdirSync` instead of `require('fs').readdirSync` and added TypeScript type annotations for better type safety.
* **Removal of `getPresentationData` function:** Eliminated redundant logic for calculating presentation page numbers, simplifying the script.
* **HTML file path handling:** Modified the script to directly load HTML files for thumbnail generation, checking both public and private directories. Added fallback logic to handle missing files gracefully.

### Logging compatibility:

* **Global logger declaration:** Removed an unnecessary ESLint directive in the global logger declaration to clean up the code.